### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ Add it to your ``INSTALLED_APPS``::
     INSTALLED_APPS = (
         ...
         'runprocess'
+        # must be placed before 'django.contrib.staticfiles'
     )
 
 Add the commands you want to be executed in the ``RUNPROCESS_PROCESSES``


### PR DESCRIPTION
The `runprocess` management command does not run unless it comes before the `staticfiles` app in `INSTALLED_APPS`.